### PR TITLE
Fix s command detection in msed_new.csh

### DIFF
--- a/msed_new.csh
+++ b/msed_new.csh
@@ -343,7 +343,7 @@ function guard_block(  plabel, elabel, pre, post) {
     n = split($0, lines, "\n")
     for (i = 1; i <= n; i++) {
         line = lines[i]
-        if (line ~ /(^|[^\\0-9A-Za-z])s[^0-9A-Za-z]/) {
+        if (line ~ /(^|[,0-9$\/\\])s[^0-9A-Za-z]/) {
             split(guard_block(), gb, "\n")
             print gb[1]
             print line


### PR DESCRIPTION
## Summary
- update the awk guard block logic to detect `s` commands following numeric or `$` addresses

## Testing
- `apt-get install -y csh`
- `echo '3s/foo/bar/' | awk -f test.awk` (manual check)


------
https://chatgpt.com/codex/tasks/task_e_6850182bd7b08333b8a12d1957d3d724