### PR TITLE
Improve s/y guard detection

### DIFF
--- a/msed_new.csh
+++ b/msed_new.csh
@@ -343,7 +343,10 @@ function guard_block(  plabel, elabel, pre, post) {
     n = split($0, lines, "\n")
     for (i = 1; i <= n; i++) {
         line = lines[i]
-        if (line ~ /(^|[,0-9$\/\\])s[^0-9A-Za-z]/) {
+        trimmed = line
+        sub(/^[ \t]*/, "", trimmed)
+        if (trimmed ~ /(^|[,0-9$\/\\])s[^0-9A-Za-z]/ ||
+            trimmed ~ /(^|[,0-9$\/\\])y[^0-9A-Za-z]/) {
             split(guard_block(), gb, "\n")
             print gb[1]
             print line


### PR DESCRIPTION
## Summary
- ensure lines starting with spaces or labels are wrapped
- handle `y` commands along with `s`

## Testing
- `printf 'abc\n' | ./msed '  s/a/b/'`
- `printf 'abc\n' | ./msed ';s/a/b/'`
- `printf 'abc\n' | ./msed ':foo; y/a/b/'`


------
https://chatgpt.com/codex/tasks/task_e_68501b244fb4833394ee7ad21d47df94