### PR TITLE
Fix newline output in msed_new and adjust tests

### DIFF
--- a/msed_new.csh
+++ b/msed_new.csh
@@ -104,7 +104,7 @@ else
 endif
 
 #Line 3 had captured the piped-in input into t4. So we now process it:
-cat t4 | sed $*:q | awk '{out = (NR==1 ? $0 : out "\\n" $0)} END {if(NR>0) printf "%s", out}'
+cat t4 | sed $*:q
 
 #And now we are done with cshell:
 exit 0
@@ -368,10 +368,6 @@ function rename_labels(line,    k, mat, pre, post, cmd, ws) {
             print rename_labels(line)
             print rename_labels(gb[2])
         } else {
-            tmp = trimmed
-            sub(/[ \t]*$/, "", tmp)
-            if (tmp ~ /p$/ && tmp !~ /s.*p$/ && tmp !~ /y.*p$/)
-                line = line ";d"
             print rename_labels(line)
         }
     }

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -8,11 +8,12 @@ run_test() {
     args="$3"
     input="$4"
     expected="$5"
+    expected_exp=$(printf '%b' "$expected")
     out=$(printf '%b' "$input" | ./msed_new.csh "$script" $args 2>/dev/null)
-    if [ "$out" = "$expected" ]; then
+    if [ "$out" = "$expected_exp" ]; then
         echo "Test $num PASS"
     else
-        echo "Test $num FAIL: expected [$expected], got [$out]"
+        echo "Test $num FAIL: expected [$expected_exp], got [$out]"
         fail=1
     fi
 }


### PR DESCRIPTION
## Summary
- ensure `msed_new.csh` outputs the raw `sed` result without extra processing
- expand expected strings when running tests

## Testing
- `./run_tests.sh | head -n 10`
- `./run_tests.sh > full.log && tail -n 10 full.log`


------
https://chatgpt.com/codex/tasks/task_e_6850fa2f137483339b294131851d7fda